### PR TITLE
feat: add `/alpha` page for testing

### DIFF
--- a/src/components/instructions.tsx
+++ b/src/components/instructions.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import Spacer from './helpers/spacer';
+
+type InstructionsProps = {
+  repo: string;
+  repoName: string;
+};
+
+export const Instructions = ({ repo, repoName }: InstructionsProps) => {
+  return (
+    <section id='instructions'>
+      <h2>How to run the courses</h2>
+      <Spacer />
+      <h3>Prerequisites</h3>
+      <p>
+        Before you get started, make sure you have these installed on your
+        computer:
+      </p>
+      <ul className='prerequisites'>
+        <li>
+          <a
+            target='_blank'
+            rel='noreferrer'
+            href='https://docs.docker.com/engine/'
+          >
+            Docker Engine
+          </a>
+        </li>
+        <li>
+          <a
+            target='_blank'
+            rel='noreferrer'
+            href='https://code.visualstudio.com/download'
+          >
+            VS Code
+          </a>{' '}
+          and the{' '}
+          <a
+            target='_blank'
+            rel='noreferrer'
+            href='https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers'
+          >
+            Dev Containers
+          </a>{' '}
+          extension
+        </li>
+        <li>Git</li>
+      </ul>
+      <h3>How to Run the Courses in Docker</h3>
+      <p>Follow these instructions to clone the repo and run the courses:</p>
+      <ol>
+        <li>
+          Open a terminal and clone the{' '}
+          <a target='_blank' rel='noreferrer' href={repo}>
+            {repoName}
+          </a>{' '}
+          repo with: <code>git clone {repo}</code>
+        </li>
+      </ol>
+      <ol start={2}>
+        <li>
+          Navigate to the <code>{repoName}</code> directory, and open it in a VS
+          Code workspace with: <code>code .</code>
+        </li>
+      </ol>
+      <ol start={3} className='instructions'>
+        <li>
+          Press <code>Ctrl / Cmd + Shift + P</code> to open the command palette,
+          and run{' '}
+          <code>Dev Containers: Rebuild Container and Reopen in Container</code>
+          . VS Code will build the container to run the projects in, it will
+          take a few minutes the first time.
+        </li>
+        <li>
+          Once it's finished, press <code>Ctrl / Cmd + Shift + P</code> again
+          and run <code>freeCodeCamp: Run Course</code> to start the courses.
+          This will also take a moment.
+        </li>
+        <li>
+          The simple browser will open when it's done. If it's a blank white
+          page, use the refresh button to update it and see the courses home
+          page.
+        </li>
+        <li>Click on one of the available projects to start a project.</li>
+        <li>Follow the instructions to complete the project.</li>
+      </ol>
+      <p>
+        If you want to switch projects, click the freeCodeCamp logo at the top
+        to get back to the home page.
+      </p>
+    </section>
+  );
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,7 @@ import Home from './pages/home';
 import Superblock from './pages/superblock';
 import Nav from './components/nav';
 import Spacer from './components/helpers/spacer';
+import { Alpha } from './pages/alpha';
 
 import './fonts.css';
 import './variables.css';
@@ -51,6 +52,7 @@ root.render(
           path={`${coursePaths.near}/*`}
           element={<Navigate to={coursePaths.near} replace />}
         />
+        <Route path='/alpha/:course' element={<Alpha />} />
         <Route path='*' element={<Navigate to='/' replace />} />
       </Routes>
       <Spacer size={3} />

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+
+type PropsType = {
+  path: string;
+};
+
+export const FourZeroFour = ({ path }: PropsType) => {
+  const location = useLocation();
+  return (
+    <main className='main'>
+      <h1>404</h1>
+      <h2>Page not found</h2>
+      <p>Unable to navigate to {location.pathname}</p>
+    </main>
+  );
+};

--- a/src/pages/alpha.tsx
+++ b/src/pages/alpha.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import { Instructions } from '../components/instructions';
+
+export const Alpha = () => {
+  const { course } = useParams();
+  return (
+    <main>
+      <Instructions
+        repo={
+          (course &&
+            `https://github.com/freeCodeCamp/${course}-curriculum.git`) ||
+          ''
+        }
+        repoName={course || ''}
+      />
+      <section>
+        <h2>Thanks for being an alpha tester 🎉</h2>
+        <p>
+          Please open an issue on GitHub with feedback. All feedback is welcome.
+        </p>
+        <p>Here are some things that would be helpful:</p>
+        <ol>
+          <li>Are the instructions accurate?</li>
+          <li>Were you able to start the course?</li>
+          <li>Was the project accurate?</li>
+          <li>Did you enjoy the project?</li>
+          <li>Did you struggle with any specific lessons/steps?</li>
+          <li>Did you experience any bugs 🐛</li>
+        </ol>
+      </section>
+    </main>
+  );
+};

--- a/src/pages/alpha.tsx
+++ b/src/pages/alpha.tsx
@@ -1,19 +1,19 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import { Instructions } from '../components/instructions';
 
 export const Alpha = () => {
   const { course } = useParams();
   return (
-    <main>
-      <Instructions
-        repo={
-          (course &&
-            `https://github.com/freeCodeCamp/${course}-curriculum.git`) ||
-          ''
-        }
-        repoName={course || ''}
-      />
+    <main className='main'>
+      <section id='instructions'>
+        <p>
+          Follow the instructions at <a href={`/${course}`}>/{course}</a>.
+        </p>
+        <p>
+          After cloning the repo, checkout the <code>next</code> branch to work
+          with the alpha content.
+        </p>
+      </section>
       <section>
         <h2>Thanks for being an alpha tester 🎉</h2>
         <p>
@@ -21,8 +21,6 @@ export const Alpha = () => {
         </p>
         <p>Here are some things that would be helpful:</p>
         <ol>
-          <li>Are the instructions accurate?</li>
-          <li>Were you able to start the course?</li>
           <li>Was the project accurate?</li>
           <li>Did you enjoy the project?</li>
           <li>Did you struggle with any specific lessons/steps?</li>

--- a/src/pages/alpha.tsx
+++ b/src/pages/alpha.tsx
@@ -1,13 +1,30 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
+import { coursesInfo, courseTitles } from '../static/courses';
+import { FourZeroFour } from './404';
+
+type ParamType = {
+  course: keyof typeof courseTitles;
+};
 
 export const Alpha = () => {
-  const { course } = useParams();
+  const { course } = useParams<ParamType>();
+  const courseInfo = coursesInfo.find(c => c.name === course);
+
+  if (!courseInfo) {
+    return (
+      <>
+        <FourZeroFour path={course || ''} />
+      </>
+    );
+  }
+
   return (
     <main className='main'>
       <section id='instructions'>
         <p>
-          Follow the instructions at <a href={`/${course}`}>/{course}</a>.
+          To test the unreleased {courseInfo.title} courses, follow the
+          instructions at <a href={`/${course}`}>/{course}</a>.
         </p>
         <p>
           After cloning the repo, checkout the <code>next</code> branch to work
@@ -17,14 +34,18 @@ export const Alpha = () => {
       <section>
         <h2>Thanks for being an alpha tester 🎉</h2>
         <p>
-          Please open an issue on GitHub with feedback. All feedback is welcome.
+          Please{' '}
+          <a href={`${courseInfo.repo}/issues/new`} target='_blank'>
+            open an issue on GitHub
+          </a>{' '}
+          with feedback. All feedback is welcome.
         </p>
         <p>Here are some things that would be helpful:</p>
         <ol>
           <li>Was the project accurate?</li>
           <li>Did you enjoy the project?</li>
           <li>Did you struggle with any specific lessons/steps?</li>
-          <li>Did you experience any bugs 🐛</li>
+          <li>Did you experience any bugs 🐛?</li>
         </ol>
       </section>
     </main>

--- a/src/pages/superblock.tsx
+++ b/src/pages/superblock.tsx
@@ -4,6 +4,7 @@ import Logo from '../components/helpers/logo';
 import { coursesInfo } from '../static/courses';
 
 import './superblock.css';
+import { Instructions } from '../components/instructions';
 
 interface SuperblockProps {
   superblock: string;
@@ -49,89 +50,7 @@ const Superblock = ({ superblock }: SuperblockProps) => {
       </section>
       <Spacer size={2} />
 
-      <section id='instructions'>
-        <h2>How to run the courses</h2>
-        <Spacer />
-        <h3>Prerequisites</h3>
-        <p>
-          Before you get started, make sure you have these installed on your
-          computer:
-        </p>
-        <ul className='prerequisites'>
-          <li>
-            <a
-              target='_blank'
-              rel='noreferrer'
-              href='https://docs.docker.com/engine/'
-            >
-              Docker Engine
-            </a>
-          </li>
-          <li>
-            <a
-              target='_blank'
-              rel='noreferrer'
-              href='https://code.visualstudio.com/download'
-            >
-              VS Code
-            </a>{' '}
-            and the{' '}
-            <a
-              target='_blank'
-              rel='noreferrer'
-              href='https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers'
-            >
-              Dev Containers
-            </a>{' '}
-            extension
-          </li>
-          <li>Git</li>
-        </ul>
-        <h3>How to Run the Courses in Docker</h3>
-        <p>Follow these instructions to clone the repo and run the courses:</p>
-        <ol>
-          <li>
-            Open a terminal and clone the{' '}
-            <a target='_blank' rel='noreferrer' href={repo}>
-              {repoName}
-            </a>{' '}
-            repo with: <code>git clone {repo}</code>
-          </li>
-        </ol>
-        <ol start={2}>
-          <li>
-            Navigate to the <code>{repoName}</code> directory, and open it in a
-            VS Code workspace with: <code>code .</code>
-          </li>
-        </ol>
-        <ol start={3} className='instructions'>
-          <li>
-            Press <code>Ctrl / Cmd + Shift + P</code> to open the command
-            palette, and run{' '}
-            <code>
-              Dev Containers: Rebuild Container and Reopen in Container
-            </code>
-            . VS Code will build the container to run the projects in, it will
-            take a few minutes the first time.
-          </li>
-          <li>
-            Once it's finished, press <code>Ctrl / Cmd + Shift + P</code> again
-            and run <code>freeCodeCamp: Run Course</code> to start the courses.
-            This will also take a moment.
-          </li>
-          <li>
-            The simple browser will open when it's done. If it's a blank white
-            page, use the refresh button to update it and see the courses home
-            page.
-          </li>
-          <li>Click on one of the available projects to start a project.</li>
-          <li>Follow the instructions to complete the project.</li>
-        </ol>
-        <p>
-          If you want to switch projects, click the freeCodeCamp logo at the top
-          to get back to the home page.
-        </p>
-      </section>
+      <Instructions repo={repo} repoName={repoName} />
     </main>
   );
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["WebWorker", "DOM", "DOM.Iterable"],
+    "lib": ["WebWorker", "DOM", "DOM.Iterable", "ESNext"],
     "target": "es2020",
     "module": "es2020",
     "moduleResolution": "node",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

With this, we can link people to `web3.freecodecamp.org/alpha/web3`, and they will get a page of instructions for alpha testing

<details>
  <summary>Image</summary>
<img width="544" alt="image" src="https://user-images.githubusercontent.com/51722130/199757772-dbe7e612-9702-4d56-8c87-efb7770a5b23.png">

</details>