### PR TITLE
fix: issue with persisted scroll state

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,14 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { RouterProvider } from 'react-router-dom';
 
-import { coursePaths, courseNames } from './static/courses';
-
-import Home from './pages/home';
-import Superblock from './pages/superblock';
-import Nav from './components/nav';
-import Spacer from './components/helpers/spacer';
-import { Alpha } from './pages/alpha';
+import router from './router';
 
 import './fonts.css';
 import './variables.css';
@@ -21,41 +15,9 @@ if (!rootElement) {
 }
 
 const root = ReactDOM.createRoot(rootElement);
+
 root.render(
   <React.StrictMode>
-    <BrowserRouter>
-      <Nav />
-      <Spacer size={3} />
-      <Routes>
-        <Route path='/' element={<Home />} />
-        <Route
-          path={coursePaths.web3}
-          element={<Superblock superblock={courseNames.web3} />}
-        />
-        <Route
-          path={`${coursePaths.web3}/*`}
-          element={<Navigate to={coursePaths.web3} replace />}
-        />
-        <Route
-          path={coursePaths.solana}
-          element={<Superblock superblock={courseNames.solana} />}
-        />
-        <Route
-          path={`${coursePaths.solana}/*`}
-          element={<Navigate to={coursePaths.solana} replace />}
-        />
-        <Route
-          path={coursePaths.near}
-          element={<Superblock superblock={courseNames.near} />}
-        />
-        <Route
-          path={`${coursePaths.near}/*`}
-          element={<Navigate to={coursePaths.near} replace />}
-        />
-        <Route path='/alpha/:course' element={<Alpha />} />
-        <Route path='*' element={<Navigate to='/' replace />} />
-      </Routes>
-      <Spacer size={3} />
-    </BrowserRouter>
+    <RouterProvider router={router} />
   </React.StrictMode>
 );

--- a/src/layout.tsx
+++ b/src/layout.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Outlet, ScrollRestoration } from 'react-router-dom';
+import Spacer from './components/helpers/spacer';
+import Nav from './components/nav';
+
+const RootLayout = () => {
+  return (
+    <>
+      <Nav />
+      <Spacer size={3} />
+      <Outlet />
+      <Spacer size={3} />
+      <ScrollRestoration />
+    </>
+  );
+};
+
+export default RootLayout;

--- a/src/pages/superblock.tsx
+++ b/src/pages/superblock.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import Spacer from '../components/helpers/spacer';
 import Logo from '../components/helpers/logo';
 import { coursesInfo } from '../static/courses';
@@ -29,8 +30,8 @@ const Superblock = ({ superblock }: SuperblockProps) => {
       <section className='section'>
         <p>{description}</p>
         <p>
-          <a href='#instructions'>Jump to the instructions at the bottom</a> to
-          learn how to run the courses.
+          <Link to='#instructions'>Jump to the instructions at the bottom</Link>{' '}
+          to learn how to run the courses.
         </p>
         <Spacer size={2} />
       </section>

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import {
+  Route,
+  Navigate,
+  createBrowserRouter,
+  createRoutesFromElements
+} from 'react-router-dom';
+
+import { coursePaths, courseNames } from './static/courses';
+
+import RootLayout from './layout';
+import Home from './pages/home';
+import Superblock from './pages/superblock';
+import { Alpha } from './pages/alpha';
+
+const router = createBrowserRouter(
+  createRoutesFromElements(
+    <Route path='/' element={<RootLayout />}>
+      <Route index element={<Home />} />
+      <Route
+        path={coursePaths.web3}
+        element={<Superblock superblock={courseNames.web3} />}
+      />
+      <Route
+        path={`${coursePaths.web3}/*`}
+        element={<Navigate to={coursePaths.web3} replace />}
+      />
+      <Route
+        path={coursePaths.solana}
+        element={<Superblock superblock={courseNames.solana} />}
+      />
+      <Route
+        path={`${coursePaths.solana}/*`}
+        element={<Navigate to={coursePaths.solana} replace />}
+      />
+      <Route
+        path={coursePaths.near}
+        element={<Superblock superblock={courseNames.near} />}
+      />
+      <Route
+        path={`${coursePaths.near}/*`}
+        element={<Navigate to={coursePaths.near} replace />}
+      />
+      <Route path='/alpha/:course' element={<Alpha />} />
+      <Route path='*' element={<Navigate to='/' replace />} />
+    </Route>
+  )
+);
+
+export default router;


### PR DESCRIPTION
Changes: 
* use newer react-router-dom@6.4 data apis instead of BrowserRouter
* use `<ScrollRestoration />` from the above data router to fix the issue
* refactor and add a root layout
* replace `<a />` tag with `<Link />` as jump to section wasn't working with the above changes

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #19 

<!-- Feel free to add any additional description of changes below this line -->

Resources: 
1. [This video](https://youtu.be/L2kzUg6IzxM?t=491) from Max for converting to data apis.  
2. [ScrollRestoration docs](https://reactrouter.com/en/main/components/scroll-restoration)
3. [Data router docs](https://reactrouter.com/en/main/routers/picking-a-router)
4. [This answer](https://stackoverflow.com/a/70220520/7358595)